### PR TITLE
feat(net/five): block deletion of server-setter vehicles

### DIFF
--- a/code/components/citizen-server-impl/include/state/ServerGameState.h
+++ b/code/components/citizen-server-impl/include/state/ServerGameState.h
@@ -924,6 +924,8 @@ struct SyncEntityState
 #ifdef STATE_FIVE
 	bool allowRemoteSyncedScenes = false;
 #endif
+	bool serverCreated = false;
+	bool rejectClientDeletion = false;
 
 	std::list<std::function<void(const fx::ClientSharedPtr& ptr)>> onCreationRPC;
 
@@ -937,6 +939,14 @@ public:
 	SyncEntityState(const SyncEntityState&) = delete;
 
 	virtual ~SyncEntityState();
+
+	inline void ResetStateForSlot(const uint32_t slotId)
+	{
+		std::lock_guard<std::shared_mutex> _(guidMutex);
+		relevantTo.reset(slotId);
+		deletedFor.reset(slotId);
+		outOfScopeFor.reset(slotId);
+	}
 
 	inline bool HasStateBag()
 	{
@@ -999,12 +1009,12 @@ public:
 
 	inline bool IsOwnedByClientScript()
 	{
-		return GetScriptHash() != 0 && creationToken == 0;
+		return (GetScriptHash() != 0 && creationToken == 0) && !serverCreated;
 	}
 
 	inline bool IsOwnedByServerScript()
 	{
-		return GetScriptHash() != 0 && creationToken != 0;
+		return (GetScriptHash() != 0 && creationToken != 0) || serverCreated;
 	}
 
 	// MAKE SURE YOU HAVE A LOCK BEFORE CALLING THIS
@@ -1618,6 +1628,12 @@ private:
 	void SendArrayData(const fx::ClientSharedPtr& client);
 
 public:
+	/// <summary>
+	/// Moves the entity to another player that the entity is relevant to
+	/// </summary>
+	/// <param name="entity"></param>
+	/// <param name="client"></param>
+	/// <returns>This returns false if there wasn't a client this entity is relevant to, AND the entity wasn't server created</returns>
 	bool MoveEntityToCandidate(const fx::sync::SyncEntityPtr& entity, const fx::ClientSharedPtr& client);
 
 	void SendPacket(int peer, net::packet::StateBagPacket& packet) override;

--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -95,6 +95,10 @@ std::shared_ptr<ConVar<fx::OneSyncState>> g_oneSyncVar;
 std::shared_ptr<ConVar<bool>> g_oneSyncPopulation;
 std::shared_ptr<ConVar<bool>> g_oneSyncARQ;
 
+// disallow client from deleting server side entities
+std::shared_ptr<ConVar<bool>> g_disallowClientDeleteVar;
+static bool g_disallowClientDelete;
+
 static std::shared_ptr<ConVar<bool>> g_networkedSoundsEnabledVar;
 static bool g_networkedSoundsEnabled;
 
@@ -2932,12 +2936,7 @@ void ServerGameState::HandleClientDrop(const fx::ClientSharedPtr& client, uint16
 
 			if (hasSlotId)
 			{
-				{
-					std::lock_guard<std::shared_mutex> _(entity->guidMutex);
-					entity->relevantTo.reset(slotId);
-					entity->deletedFor.reset(slotId);
-					entity->outOfScopeFor.reset(slotId);
-				}
+				entity->ResetStateForSlot(slotId);
 
 				{
 					std::lock_guard _(entity->frameMutex);
@@ -3152,7 +3151,7 @@ void ServerGameState::ProcessCloneRemove(const fx::ClientSharedPtr& client, rl::
 
 	auto entity = GetEntity(0, objectId);
 
-	// ack remove no matter if we accept it
+	// ack remove as the calling client will have removed this entity anyways
 	ackPacket.Write(3, 3);
 	ackPacket.Write(13, objectId);
 	ackPacket.Write(16, uniqifier);
@@ -3172,6 +3171,28 @@ void ServerGameState::ProcessCloneRemove(const fx::ClientSharedPtr& client, rl::
 		if (entity->uniqifier != uniqifier)
 		{
 			GS_LOG("%s: wrong uniqifier (%d - %d->%d)\n", __func__, objectId, uniqifier, entity->uniqifier);
+
+			return;
+		}
+
+		if (entity->rejectClientDeletion)
+		{
+			const auto clientData = GetClientDataUnlocked(this, client);
+			const auto entIdentifier = MakeHandleUniqifierPair(objectId, uniqifier);
+			if (auto syncData = clientData->syncedEntities.find(entIdentifier); syncData != clientData->syncedEntities.end())
+			{
+				GS_LOG("%s: tried to delete server spawned entity setting entity id %d to be recreated for client %d\n", __func__, objectId, client->GetNetId());
+				// Reset the created state so they will get resent the entity data on the next server tick
+				syncData->second.hasCreated = false;
+				syncData->second.hasNAckedCreate = false;
+			}
+
+			// the client no longer has the entity created for them, cleanup all relevant state
+			entity->ResetStateForSlot(client->GetSlotId());
+
+			// since the client no longer has the entity created we should move the ownership back to the server
+			// and let the server handle ownership of the entity on the next tick
+			ReassignEntity(entity->handle, {});
 
 			return;
 		}
@@ -3293,6 +3314,8 @@ auto ServerGameState::CreateEntityFromTree(sync::NetObjEntityType type, const st
 	entity->creationToken = msec().count();
 	entity->createdAt = msec();
 	entity->passedFilter = true;
+	entity->serverCreated = true;
+	entity->rejectClientDeletion = g_disallowClientDelete;
 
 	entity->syncTree = tree;
 
@@ -7790,6 +7813,7 @@ static InitFunction initFunction([]()
 
 		g_requestControlVar = instance->AddVariable<int>("sv_filterRequestControl", ConVar_None, (int)RequestControlFilterMode::NoFilter, (int*)&g_requestControlFilterState);
 		g_requestControlSettleVar = instance->AddVariable<int>("sv_filterRequestControlSettleTimer", ConVar_None, 30000, &g_requestControlSettleDelay);
+		g_disallowClientDeleteVar = instance->AddVariable<bool>("sv_disallowClientDelete", ConVar_None, false, &g_disallowClientDelete);
 
 		fx::SetOneSyncGetCallback([]()
 		{

--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -1640,6 +1640,25 @@ static void Init()
 		return int(entity->routingBucket);
 	}));
 
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_ENTITY_REJECTS_CLIENT_DELETION", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		if (!entity->serverCreated)
+		{
+			return false;
+		}
+
+		if (context.GetArgumentCount() > 1)
+		{
+			auto rejectClientDelete = context.GetArgument<bool>(1);
+
+			entity->rejectClientDeletion = rejectClientDelete;
+		}
+
+		return true;
+	}));
+
+
 	fx::ScriptEngine::RegisterNativeHandler("SET_ENTITY_ROUTING_BUCKET", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
 	{
 		if (context.GetArgumentCount() > 1)

--- a/code/components/gta-net-five/src/ClientRPC.cpp
+++ b/code/components/gta-net-five/src/ClientRPC.cpp
@@ -201,7 +201,7 @@ int ObjectToEntity(int objectId);
 namespace sync
 {
 std::map<int, int> g_creationTokenToObjectId;
-std::map<int, uint32_t> g_objectIdToCreationToken;
+std::map<int, uint32_t> g_RPCObjIdToCreationToken;
 
 static hook::cdecl_stub<void*(int handle)> getScriptEntity([]()
 {
@@ -528,7 +528,7 @@ public:
 
 									g_creationTokenToObjectId[creationToken] = (1 << 16) | obj;
 
-									g_objectIdToCreationToken[obj] = creationToken;
+									g_RPCObjIdToCreationToken[obj] = creationToken;
 								}
 							}
 						}

--- a/code/components/gta-net-five/src/CloneManager.cpp
+++ b/code/components/gta-net-five/src/CloneManager.cpp
@@ -920,7 +920,9 @@ void msgPackedClones::Read(net::Buffer& buffer)
 void TempHackMakePhysicalPlayer(uint16_t clientId, int slotId = -1);
 
 extern std::map<int, int> g_creationTokenToObjectId;
-extern std::map<int, uint32_t> g_objectIdToCreationToken;
+//Used by ClientRPC.cpp
+extern std::map<int, uint32_t> g_RPCObjIdToCreationToken;
+std::unordered_map<int, uint32_t> g_objectIdToCreationToken;
 
 rage::netObject* CloneManagerLocal::GetNetObject(uint16_t objectId)
 {
@@ -1133,6 +1135,7 @@ bool CloneManagerLocal::HandleCloneCreate(const msgClone& msg)
 	if (msg.m_creationToken != 0)
 	{
 		g_creationTokenToObjectId[msg.m_creationToken] = msg.GetObjectId();
+		g_objectIdToCreationToken[msg.GetObjectId()] = msg.m_creationToken;
 	}
 
 	ackPacket();
@@ -1955,6 +1958,8 @@ void CloneManagerLocal::DestroyNetworkObject(rage::netObject* object)
 	m_savedEntitySet.erase(object);
 	m_trackedObjects.erase(object->GetObjectId());
 	m_extendedData.erase(object->GetObjectId());
+
+	g_objectIdToCreationToken.erase(object->GetObjectId());
 
 	m_savedEntityVec.erase(std::remove(m_savedEntityVec.begin(), m_savedEntityVec.end(), object), m_savedEntityVec.end());
 }

--- a/code/components/gta-net-five/src/NetServerObject.cpp
+++ b/code/components/gta-net-five/src/NetServerObject.cpp
@@ -1,0 +1,91 @@
+/*
+* This file is part of the CitizenFX project - http://citizen.re/
+*
+* See LICENSE and MENTIONS in the root of the source tree for information
+* regarding licensing.
+*/
+
+#include <StdInc.h>
+#include <Hooking.h>
+#include <MinHook.h>
+#include <netObject.h>
+#include <ICoreGameInit.h>
+#include <NetLibrary.h>
+#include <EntitySystem.h>
+#include <CoreConsole.h>
+
+static ICoreGameInit* icgi;
+
+static bool g_protectServerEntity = true;
+
+namespace sync
+{
+	extern std::unordered_map<int, uint32_t> g_objectIdToCreationToken;
+}
+
+static bool CanEntityBeDeleted(rage::netObject* netObject)
+{
+	if (!g_protectServerEntity)
+	{
+		return true;
+	}
+
+	uint16_t creationToken = sync::g_objectIdToCreationToken[netObject->GetObjectId()];
+
+	if (creationToken != 0)
+	{
+		trace("blocking deletion of server-entity %i, bool %i\n", netObject->GetObjectId(), (netObject->syncData.wantsToDelete && !netObject->syncData.shouldNotBeDeleted));
+		return netObject->syncData.wantsToDelete && !netObject->syncData.shouldNotBeDeleted;
+	}
+
+	return true;
+}
+
+static void (*g_origCVehicleFactoryDestroy)(void*, CVehicle*, bool);
+static void CVehicleFactory_Destroy(void* self, CVehicle* vehicle, bool unk)
+{
+	if (!icgi->OneSyncEnabled || !vehicle->GetNetObject() ||  CanEntityBeDeleted((rage::netObject*)vehicle->GetNetObject()))
+	{
+		g_origCVehicleFactoryDestroy(self, vehicle, unk);
+	}
+}
+
+static void (*g_origCPedFactoryDestory)(void*, fwEntity*, bool);
+static void CPedFactory_Destory(void* self, fwEntity* ped, bool unk)
+{
+	if (!icgi->OneSyncEnabled || !ped->GetNetObject() || CanEntityBeDeleted((rage::netObject*)ped->GetNetObject()))
+	{
+		g_origCPedFactoryDestory(self, ped, unk);
+	}
+}
+
+static void (*g_destroyObject)(fwEntity*, int);
+static void DestroyObject(fwEntity* object, int unk)
+{
+	if (!icgi->OneSyncEnabled || !object->GetNetObject() || CanEntityBeDeleted((rage::netObject*)object->GetNetObject()))
+	{
+		g_destroyObject(object, unk);
+	}
+}
+
+static HookFunction hookFunction([]()
+{
+	static ConVar<bool> protectServerEntities("sv_disallowClientDelete", ConVar_Replicated, false, &g_protectServerEntity);
+
+	// Block the client from being able to delete server-setter entities if "sv_disallowClientDelete" is set . This prevents the deleted object from "flickering" as it gets instantly re-created by the server
+	{
+		MH_Initialize();
+		MH_CreateHook(hook::get_pattern("48 89 5C 24 ? 48 89 74 24 ? 57 48 83 EC ? FF 05"), CVehicleFactory_Destroy, (void**)&g_origCVehicleFactoryDestroy);
+		MH_CreateHook(hook::get_pattern("48 8B F1 48 85 D2 74 ? 48 8B 8A", -0x15), CPedFactory_Destory, (void**)&g_origCPedFactoryDestory);
+		MH_CreateHook(hook::get_call(hook::get_pattern("E8 ? ? ? ? 48 85 FF 74 ? F7 87")), DestroyObject, (void**)&g_destroyObject);
+		MH_EnableHook(MH_ALL_HOOKS);
+	}
+});
+
+static InitFunction initFunctionSv([]()
+{
+	NetLibrary::OnNetLibraryCreate.Connect([](NetLibrary* netLibrary)
+	{
+		icgi = Instance<ICoreGameInit>::Get();
+	});
+});

--- a/ext/native-decls/SetEntityRejectClientDeletion.md
+++ b/ext/native-decls/SetEntityRejectClientDeletion.md
@@ -1,0 +1,21 @@
+---
+ns: CFX
+apiset: server
+---
+## SET_ENTITY_REJECTS_CLIENT_DELETION
+
+```c
+void SET_ENTITY_REJECTS_CLIENT_DELETION(Entity entity, bool rejectClientDelete);
+```
+
+This native only works on server-created vehicles.
+
+Sets a flag for the server to reject any client side deletion of this entity.
+
+This currently *doesn't* stop the entity from being deleted on the calling client, it will just recreate the entity for the caller and reset the relevant state on the server.
+
+This flag will default to the value of "sv_disallowClientDelete" when the entity was created
+
+## Parameters
+* **entity**: The entity to reject deletion of
+* **rejectClientDelete**: A boolean of whether the server should reject client delete, or accept it


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

...


### How is this PR achieving the goal

...


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

...


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [ ] Code compiles and has been tested successfully.
- [ ] Code explains itself well and/or is documented.
- [ ] My commit message explains what the changes do and what they are for.
- [ ] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


