### PR TITLE
feat(net/five): block deletion of server-setter vehicles

### DIFF
--- a/code/components/gta-net-five/src/ClientRPC.cpp
+++ b/code/components/gta-net-five/src/ClientRPC.cpp
@@ -201,7 +201,7 @@ int ObjectToEntity(int objectId);
 namespace sync
 {
 std::map<int, int> g_creationTokenToObjectId;
-std::map<int, uint32_t> g_objectIdToCreationToken;
+std::map<int, uint32_t> g_RPCObjIdToCreationToken;
 
 static hook::cdecl_stub<void*(int handle)> getScriptEntity([]()
 {
@@ -528,7 +528,7 @@ public:
 
 									g_creationTokenToObjectId[creationToken] = (1 << 16) | obj;
 
-									g_objectIdToCreationToken[obj] = creationToken;
+									g_RPCObjIdToCreationToken[obj] = creationToken;
 								}
 							}
 						}

--- a/code/components/gta-net-five/src/CloneManager.cpp
+++ b/code/components/gta-net-five/src/CloneManager.cpp
@@ -920,7 +920,9 @@ void msgPackedClones::Read(net::Buffer& buffer)
 void TempHackMakePhysicalPlayer(uint16_t clientId, int slotId = -1);
 
 extern std::map<int, int> g_creationTokenToObjectId;
-extern std::map<int, uint32_t> g_objectIdToCreationToken;
+//Used by ClientRPC.cpp
+extern std::map<int, uint32_t> g_RPCObjIdToCreationToken;
+std::unordered_map<int, uint32_t> g_objectIdToCreationToken;
 
 rage::netObject* CloneManagerLocal::GetNetObject(uint16_t objectId)
 {
@@ -1133,6 +1135,7 @@ bool CloneManagerLocal::HandleCloneCreate(const msgClone& msg)
 	if (msg.m_creationToken != 0)
 	{
 		g_creationTokenToObjectId[msg.m_creationToken] = msg.GetObjectId();
+		g_objectIdToCreationToken[msg.GetObjectId()] = msg.m_creationToken;
 	}
 
 	ackPacket();
@@ -1955,6 +1958,8 @@ void CloneManagerLocal::DestroyNetworkObject(rage::netObject* object)
 	m_savedEntitySet.erase(object);
 	m_trackedObjects.erase(object->GetObjectId());
 	m_extendedData.erase(object->GetObjectId());
+
+	g_objectIdToCreationToken.erase(object->GetObjectId());
 
 	m_savedEntityVec.erase(std::remove(m_savedEntityVec.begin(), m_savedEntityVec.end(), object), m_savedEntityVec.end());
 }

--- a/code/components/gta-net-five/src/NetServerObject.cpp
+++ b/code/components/gta-net-five/src/NetServerObject.cpp
@@ -1,0 +1,91 @@
+/*
+* This file is part of the CitizenFX project - http://citizen.re/
+*
+* See LICENSE and MENTIONS in the root of the source tree for information
+* regarding licensing.
+*/
+
+#include <StdInc.h>
+#include <Hooking.h>
+#include <MinHook.h>
+#include <netObject.h>
+#include <ICoreGameInit.h>
+#include <NetLibrary.h>
+#include <EntitySystem.h>
+#include <CoreConsole.h>
+
+static ICoreGameInit* icgi;
+
+static bool g_protectServerEntity = true;
+
+namespace sync
+{
+	extern std::unordered_map<int, uint32_t> g_objectIdToCreationToken;
+}
+
+static bool CanEntityBeDeleted(rage::netObject* netObject)
+{
+	if (!g_protectServerEntity)
+	{
+		return true;
+	}
+
+	uint16_t creationToken = sync::g_objectIdToCreationToken[netObject->GetObjectId()];
+
+	if (creationToken != 0)
+	{
+		trace("blocking deletion of server-entity %i, bool %i\n", netObject->GetObjectId(), (netObject->syncData.wantsToDelete && !netObject->syncData.shouldNotBeDeleted));
+		return netObject->syncData.wantsToDelete && !netObject->syncData.shouldNotBeDeleted;
+	}
+
+	return true;
+}
+
+static void (*g_origCVehicleFactoryDestroy)(void*, CVehicle*, bool);
+static void CVehicleFactory_Destroy(void* self, CVehicle* vehicle, bool unk)
+{
+	if (!icgi->OneSyncEnabled || !vehicle->GetNetObject() ||  CanEntityBeDeleted((rage::netObject*)vehicle->GetNetObject()))
+	{
+		g_origCVehicleFactoryDestroy(self, vehicle, unk);
+	}
+}
+
+static void (*g_origCPedFactoryDestory)(void*, fwEntity*, bool);
+static void CPedFactory_Destory(void* self, fwEntity* ped, bool unk)
+{
+	if (!icgi->OneSyncEnabled || !ped->GetNetObject() || CanEntityBeDeleted((rage::netObject*)ped->GetNetObject()))
+	{
+		g_origCPedFactoryDestory(self, ped, unk);
+	}
+}
+
+static void (*g_destroyObject)(fwEntity*, int);
+static void DestroyObject(fwEntity* object, int unk)
+{
+	if (!icgi->OneSyncEnabled || !object->GetNetObject() || CanEntityBeDeleted((rage::netObject*)object->GetNetObject()))
+	{
+		g_destroyObject(object, unk);
+	}
+}
+
+static HookFunction hookFunction([]()
+{
+	static ConVar<bool> protectServerEntities("sv_disallowClientDelete", ConVar_Replicated, false, &g_protectServerEntity);
+
+	// Block the client from being able to delete server-setter entities if "sv_disallowClientDelete" is set . This prevents the deleted object from "flickering" as it gets instantly re-created by the server
+	{
+		MH_Initialize();
+		MH_CreateHook(hook::get_pattern("48 89 5C 24 ? 48 89 74 24 ? 57 48 83 EC ? FF 05"), CVehicleFactory_Destroy, (void**)&g_origCVehicleFactoryDestroy);
+		MH_CreateHook(hook::get_pattern("48 8B F1 48 85 D2 74 ? 48 8B 8A", -0x15), CPedFactory_Destory, (void**)&g_origCPedFactoryDestory);
+		MH_CreateHook(hook::get_call(hook::get_pattern("E8 ? ? ? ? 48 85 FF 74 ? F7 87")), DestroyObject, (void**)&g_destroyObject);
+		MH_EnableHook(MH_ALL_HOOKS);
+	}
+});
+
+static InitFunction initFunctionSv([]()
+{
+	NetLibrary::OnNetLibraryCreate.Connect([](NetLibrary* netLibrary)
+	{
+		icgi = Instance<ICoreGameInit>::Get();
+	});
+});


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

...


### How is this PR achieving the goal

...


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

...


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [ ] Code compiles and has been tested successfully.
- [ ] Code explains itself well and/or is documented.
- [ ] My commit message explains what the changes do and what they are for.
- [ ] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


